### PR TITLE
Support Python3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - TOX_ENV=py27
   - TOX_ENV=py32
   - TOX_ENV=py33
+  - TOX_ENV=py34
   - TOX_ENV=pypy
 install:
   - pip install tox coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,pypy
+envlist = py26,py27,py32,py33,py34,pypy
 
 [testenv]
 commands = 
@@ -32,6 +32,11 @@ basepython = python3.2
 deps=
 		{[py]deps}
 basepython = python3.3
+
+[testenv:py34]
+deps=
+		{[py]deps}
+basepython = python3.4
 
 [testenv:pypy]
 deps=


### PR DESCRIPTION
Append py34 to tox and travis configurations according to travis-ci update.

See also:
http://blog.travis-ci.com/2014-04-28-upcoming-build-environment-updates/

Signed-off-by: Kouhei Maeda mkouhei@palmtb.net
